### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mdurl
 mkl-service==2.4.0
 nest-asyncio
 numexpr
-numpy
+numpy==1.26.4
 packaging
 pandas
 parso


### PR DESCRIPTION
Fixed numpy at v.1.26.4 as 2.0 causing backwards compatibility issues.